### PR TITLE
Increase timeout for requests

### DIFF
--- a/server.go
+++ b/server.go
@@ -408,7 +408,7 @@ func main() {
 	}
 	balancer := lb.NewRoundRobin(subscriber)
 	// Try each URL once.
-	retry := lb.Retry(len(urls), 10*time.Second, balancer)
+	retry := lb.Retry(len(urls), 1*time.Minute, balancer)
 
 	ca := crateAdapter{
 		ep: retry,


### PR DESCRIPTION
Whenever a query requires more than 10s the crate_adapter triggers a `context deadline exceeded`

Since a lot of queries might require more than 10 seconds to execute (especially when querying a large amount of data) I increased the default timeout to 1m, consistently with the `remote_read` timeout of prometheus ( https://github.com/prometheus/prometheus/blob/master/config/config.go#L130 )

In the future it probably make sense to make this timeout configurable.