### PR TITLE
Fix regular expression handling

### DIFF
--- a/server.go
+++ b/server.go
@@ -120,7 +120,7 @@ func queryToSQL(q *prompb.Query) (string, error) {
 				selectors = append(selectors, fmt.Sprintf("(%s != %s)", escapeLabelName(m.Name), escapeLabelValue(m.Value)))
 			}
 		case prompb.LabelMatcher_RE:
-			re := "^(?:" + m.Value + ")$"
+			re := "(" + m.Value + ")"
 			matchesEmpty, err := regexp.MatchString(re, "")
 			if err != nil {
 				return "", err
@@ -132,7 +132,7 @@ func queryToSQL(q *prompb.Query) (string, error) {
 				selectors = append(selectors, fmt.Sprintf("(%s ~ %s)", escapeLabelName(m.Name), escapeLabelValue(re)))
 			}
 		case prompb.LabelMatcher_NRE:
-			re := "^(?:" + m.Value + ")$"
+			re := "(" + m.Value + ")"
 			matchesEmpty, err := regexp.MatchString(re, "")
 			if err != nil {
 				return "", err


### PR DESCRIPTION
According to the [documentation](https://crate.io/docs/crate/reference/en/latest/general/dql/selects.html#regular-expressions) CrateDB regular expressions are implicitly anchored, so no need for an explicit anchor in the adapter queries - doing so produces an empty result set from CrateDB.

Original code, returns no data:
```
SELECT labels, labels_hash, timestamp, value, "valueRaw" FROM prometheus.metrics WHERE (labels['container_name'] ~ '^(?:crate|prometheus)$') AND (labels['__name__'] = 'container_cpu_usage_seconds_total') AND (timestamp <= 1551782847341) AND (timestamp >= 1551782547341) ORDER BY timestamp limit 100;
```

As per pull request, returns data:
```
SELECT labels, labels_hash, timestamp, value, "valueRaw" FROM prometheus.metrics WHERE (labels['container_name'] ~ '(crate|prometheus)') AND (labels['__name__'] = 'container_cpu_usage_seconds_total') AND (timestamp <= 1551782847341) AND (timestamp >= 1551782547341) ORDER BY timestamp limit 100;
```