### PR TITLE
Replace valueRaw with value_raw in column name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Create the following table in your CrateDB database:
       "labels_hash" STRING,
       "labels" OBJECT(DYNAMIC),
       "value" DOUBLE,
-      "valueRaw" LONG,
+      "value_raw" LONG,
       "day__generated" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', "timestamp"),
       PRIMARY KEY ("timestamp", "labels_hash", "day__generated")
     ) PARTITIONED BY ("day__generated");

--- a/crate.go
+++ b/crate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-const crateWriteStatement = `INSERT INTO metrics ("labels", "labels_hash", "timestamp", "value", "valueRaw") VALUES ($1, $2, $3, $4, $5)`
+const crateWriteStatement = `INSERT INTO metrics ("labels", "labels_hash", "timestamp", "value", "value_raw") VALUES ($1, $2, $3, $4, $5)`
 
 type crateRow struct {
 	labels     model.Metric

--- a/server.go
+++ b/server.go
@@ -147,7 +147,7 @@ func queryToSQL(q *prompb.Query) (string, error) {
 	selectors = append(selectors, fmt.Sprintf("(timestamp <= %d)", q.EndTimestampMs))
 	selectors = append(selectors, fmt.Sprintf("(timestamp >= %d)", q.StartTimestampMs))
 
-	return fmt.Sprintf(`SELECT labels, labels_hash, timestamp, value, "valueRaw" FROM metrics WHERE %s ORDER BY timestamp`, strings.Join(selectors, " AND ")), nil
+	return fmt.Sprintf(`SELECT labels, labels_hash, timestamp, value, "value_raw" FROM metrics WHERE %s ORDER BY timestamp`, strings.Join(selectors, " AND ")), nil
 }
 
 func responseToTimeseries(data *crateReadResponse) []*prompb.TimeSeries {

--- a/server_test.go
+++ b/server_test.go
@@ -25,7 +25,7 @@ func TestQueryToSQL(t *testing.T) {
 				StartTimestampMs: 1000,
 				EndTimestampMs:   2000,
 			},
-			sql: `SELECT labels, labels_hash, timestamp, value, "valueRaw" FROM metrics WHERE (timestamp <= 2000) AND (timestamp >= 1000) ORDER BY timestamp`,
+			sql: `SELECT labels, labels_hash, timestamp, value, "value_raw" FROM metrics WHERE (timestamp <= 2000) AND (timestamp >= 1000) ORDER BY timestamp`,
 		},
 		{
 			query: &prompb.Query{
@@ -38,7 +38,7 @@ func TestQueryToSQL(t *testing.T) {
 				StartTimestampMs: 1000,
 				EndTimestampMs:   2000,
 			},
-			sql: `SELECT labels, labels_hash, timestamp, value, "valueRaw" FROM metrics WHERE (labels['n'] = 'v') AND (labels['n'] != 'v') AND (labels['n'] ~ '^(?:v)$') AND (labels['n'] !~ '^(?:v)$' OR labels['n'] IS NULL) AND (timestamp <= 2000) AND (timestamp >= 1000) ORDER BY timestamp`,
+			sql: `SELECT labels, labels_hash, timestamp, value, "value_raw" FROM metrics WHERE (labels['n'] = 'v') AND (labels['n'] != 'v') AND (labels['n'] ~ '^(?:v)$') AND (labels['n'] !~ '^(?:v)$' OR labels['n'] IS NULL) AND (timestamp <= 2000) AND (timestamp >= 1000) ORDER BY timestamp`,
 		},
 		{
 			query: &prompb.Query{
@@ -52,7 +52,7 @@ func TestQueryToSQL(t *testing.T) {
 				StartTimestampMs: 1000,
 				EndTimestampMs:   2000,
 			},
-			sql: `SELECT labels, labels_hash, timestamp, value, "valueRaw" FROM metrics WHERE (labels['n\''] = 'v\'') AND (labels['n\''] != 'v\'') AND (labels['n\''] ~ '^(?:v\')$') AND (labels['n\''] !~ '^(?:v\')$' OR labels['n\''] IS NULL) AND (timestamp <= 2000) AND (timestamp >= 1000) ORDER BY timestamp`,
+			sql: `SELECT labels, labels_hash, timestamp, value, "value_raw" FROM metrics WHERE (labels['n\''] = 'v\'') AND (labels['n\''] != 'v\'') AND (labels['n\''] ~ '^(?:v\')$') AND (labels['n\''] !~ '^(?:v\')$' OR labels['n\''] IS NULL) AND (timestamp <= 2000) AND (timestamp >= 1000) ORDER BY timestamp`,
 		},
 		{
 			query: &prompb.Query{
@@ -65,7 +65,7 @@ func TestQueryToSQL(t *testing.T) {
 				StartTimestampMs: 1000,
 				EndTimestampMs:   2000,
 			},
-			sql: `SELECT labels, labels_hash, timestamp, value, "valueRaw" FROM metrics WHERE (labels['n'] IS NULL) AND (labels['n'] IS NOT NULL) AND (labels['n'] ~ '^(?:)$' OR labels['n'] IS NULL) AND (labels['n'] !~ '^(?:)$') AND (timestamp <= 2000) AND (timestamp >= 1000) ORDER BY timestamp`,
+			sql: `SELECT labels, labels_hash, timestamp, value, "value_raw" FROM metrics WHERE (labels['n'] IS NULL) AND (labels['n'] IS NOT NULL) AND (labels['n'] ~ '^(?:)$' OR labels['n'] IS NULL) AND (labels['n'] !~ '^(?:)$') AND (timestamp <= 2000) AND (timestamp >= 1000) ORDER BY timestamp`,
 		},
 		{
 			query: &prompb.Query{


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Rename valueRaw to value_raw as column name. Needed to be able to manually (backfilling) insert data in crate db. While testing a manual insert (via crate frontend) I noticed that if I inserted something in valueRaw that the camelCase is ignored. Instead it created a new column valueraw instead of filling valueRaw. Using value_raw fixes this. It's also more consistent just like labels_hash column.

## Checklist

 - [X ] [CLA](https://crate.io/community/contribute/cla/) is signed
