### PR TITLE
Fix old log message mentioning POST method

### DIFF
--- a/server.go
+++ b/server.go
@@ -329,7 +329,7 @@ func (ca *crateAdapter) handleWrite(w http.ResponseWriter, r *http.Request) {
 	writeTimer.ObserveDuration()
 	if err != nil {
 		writeCrateErrors.Inc()
-		log.With("err", err).Error("Failed to POST inserts to Crate.")
+		log.With("err", err).Error("Failed to write data to Crate.")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
I missed updating this log message when converting the adapter from HTTP
to Postgres protocol back then in 2018.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

## Summary of the changes / Why this is an improvement

The current log message is misleading / incorrect / outdated, since the adapter no longer speaks HTTP to CrateDB.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
